### PR TITLE
Fix prysk test file lookup for relative paths

### DIFF
--- a/prysk/test.py
+++ b/prysk/test.py
@@ -31,7 +31,16 @@ def _findtests(paths):
 
     def is_hidden(path):
         """Check if a path (file/dir) is hidden or not."""
-        return any(map(lambda part: part.startswith("."), path.parts))
+
+        def _is_hidden(part):
+            return (
+                part.startswith(".")
+                and not part == "."
+                and not part.startswith("..")
+                and not part.startswith("./")
+            )
+
+        return any(map(_is_hidden, path.parts))
 
     def is_testfile(path):
         """Check if path is a valid prysk test file"""

--- a/test/integration/prysk/relative.t
+++ b/test/integration/prysk/relative.t
@@ -1,0 +1,20 @@
+Set up an empty test which should be detected as test but skipped
+
+  $ touch empty.t
+
+Set up some folders so we can provide an relative path
+
+  $ mkdir -p dir/subdir
+
+Check if . is accepted as relative path
+
+  $ prysk ./empty.t
+  s
+  # Ran 1 tests, 1 skipped, 0 failed.
+
+Check if .. is accepted as relative path
+
+  $ cd dir/subdir && prysk ../..
+  s
+  # Ran 1 tests, 1 skipped, 0 failed.
+


### PR DESCRIPTION
Fixes #107

A to coarse check if a file/directory is hidden
caused relative paths to be excluded during the test file lookup.