### PR TITLE
(For discussion) numerical epsilon matching of lines

### DIFF
--- a/prysk/diff.py
+++ b/prysk/diff.py
@@ -61,6 +61,26 @@ def glob(el, l):
     return _matchannotation(b"glob", _glob, el, l)
 
 
+def epsilon(el, l):
+    """Match numerically "close" to a line annotated with '(epsilon [value])'"""
+    m = re.fullmatch(rb"(.*) \(epsilon (.+)\)\n", el)
+    if m:
+        try:
+            epsilon = float(m.group(2))
+            a = re.split(rb'\s+', m.group(1))
+            b = re.split(rb'\s+', l[:-1])
+            if len(a) and len(b):
+                for i in range(len(a)):
+                    if a[i] == b[i]:
+                        continue
+                    if abs(float(a[i]) - float(b[i])) > epsilon:
+                        return False
+            return True
+        except:
+            return False
+    return False
+
+
 def esc(el, l):
     """Apply an escape match to a line annotated with '(esc)'"""
     ann = b" (esc)\n"

--- a/prysk/test.py
+++ b/prysk/test.py
@@ -11,6 +11,7 @@ from prysk.diff import (
     esc,
     glob,
     regex,
+    epsilon,
     unified_diff,
 )
 from prysk.process import (
@@ -231,7 +232,7 @@ def test(
         diff_path = error_path = b""
 
     diff = unified_diff(
-        refout, postout, diff_path, error_path, matchers=[esc, glob, regex]
+        refout, postout, diff_path, error_path, matchers=[esc, glob, regex, epsilon]
     )
     for line in diff:
         return refout, postout, itertools.chain([line], diff)

--- a/test.t
+++ b/test.t
@@ -1,0 +1,11 @@
+
+Within 10cm
+
+  $ echo 1.0
+  1.01 (epsilon 0.10)
+
+Within 2m
+
+  $ echo 999.9
+  1001.1 (epsilon 2.0)
+


### PR DESCRIPTION
This is a proof-of-concept implementation of matching numeric results within a specified "epsilon" or tolerable error margin.

The broad idea is that for CSV, whitespace seperated or tabular numerical output we can tolerate some numerical variation while checking that the results are "near enough".

Filing this for further discussion about refining this concept for eventual acceptance here.