### PR TITLE
Convert Windows line endings to UNIX for cross-platform purposes

### DIFF
--- a/prysk/cli.py
+++ b/prysk/cli.py
@@ -191,6 +191,11 @@ class _ArgumentParser:
             metavar="PATH",
             help="path to write xUnit XML output",
         )
+        parser.add_argument(
+            "--dos2unix",
+            action="store_true",
+            help="convert DOS/Windows line endings to UNIX line endings",
+        )
         return parser
 
     def __init__(self, *args, **kwargs):
@@ -488,6 +493,7 @@ class _Cli:
                 indent=settings.indent,
                 cleanenv=not settings.preserve_env,
                 debug=settings.debug,
+                dos2unix=settings.dos2unix
             )
             if not settings.debug:
                 tests = self._runcli(

--- a/prysk/settings.py
+++ b/prysk/settings.py
@@ -21,6 +21,7 @@ class Settings:
     indent: int = None
     color: str = "auto"
     xunit_file: str = None
+    dos2unix: bool = None
 
 
 def settings_from(obj):

--- a/prysk/test.py
+++ b/prysk/test.py
@@ -179,6 +179,9 @@ def test(
     i = pos = prepos = -1
     stdin = []
     for i, line in enumerate(lines):
+        # Convert Windows style line endings to UNIX
+        if line.endswith(b"\r\n"):
+            line = line[:-2] + b"\n"
         if not line.endswith(b"\n"):
             line += b"\n"
         refout.append(line)
@@ -208,6 +211,9 @@ def test(
             out, cmd = line.split(salt, 1)
 
         if out:
+            # Convert Windows style line endings to UNIX
+            if out.endswith(b"\r\n"):
+                out = out[:-2] + b"\n"
             if not out.endswith(b"\n"):
                 out += b" (no-eol)\n"
 

--- a/prysk/test.py
+++ b/prysk/test.py
@@ -93,6 +93,7 @@ def test(
     env=None,
     cleanenv=True,
     debug=False,
+    dos2unix=False,
 ):
     r"""Run test lines and return input, output, and diff.
 
@@ -148,6 +149,8 @@ def test(
     :type cleanenv: bool
     :param debug: Whether or not to run in debug mode (don't capture stdout)
     :type debug: bool
+    :param dos2unix: Whether or not to convert all DOS/Windows line endings to UNIX
+    :type debug: bool
     return: Input, output, and diff iterables
     :rtype: (list[bytes], list[bytes], collections.Iterable[bytes])
     """
@@ -180,7 +183,7 @@ def test(
     stdin = []
     for i, line in enumerate(lines):
         # Convert Windows style line endings to UNIX
-        if line.endswith(b"\r\n"):
+        if dos2unix and line.endswith(b"\r\n"):
             line = line[:-2] + b"\n"
         if not line.endswith(b"\n"):
             line += b"\n"
@@ -212,7 +215,7 @@ def test(
 
         if out:
             # Convert Windows style line endings to UNIX
-            if out.endswith(b"\r\n"):
+            if dos2unix and out.endswith(b"\r\n"):
                 out = out[:-2] + b"\n"
             if not out.endswith(b"\n"):
                 out += b" (no-eol)\n"
@@ -258,7 +261,7 @@ def _debug(cmdline, conline, env, lines, shell):
 
 
 def testfile(
-    path, shell="/bin/sh", indent=2, env=None, cleanenv=True, debug=False, testname=None
+    path, shell="/bin/sh", indent=2, env=None, cleanenv=True, debug=False, testname=None, dos2unix=False
 ):
     """Run test at path and return input, output, and diff.
 
@@ -306,10 +309,11 @@ def testfile(
             env=env,
             cleanenv=cleanenv,
             debug=debug,
+            dos2unix=dos2unix
         )
 
 
-def runtests(paths, tmpdir, shell, indent=2, cleanenv=True, debug=False):
+def runtests(paths, tmpdir, shell, indent=2, cleanenv=True, debug=False, dos2unix=False):
     """Run tests and yield results.
 
     This yields a sequence of 2-tuples containing the following:
@@ -351,6 +355,7 @@ def runtests(paths, tmpdir, shell, indent=2, cleanenv=True, debug=False):
                     cleanenv=cleanenv,
                     debug=debug,
                     testname=path,
+                    dos2unix=dos2unix
                 )
 
         yield path, test


### PR DESCRIPTION
One thing we'd like to do with prysk is use it for testing on Windows, as well as Linux.

One of the practicalities of that is that Windows emits different line endings, but it seems simple enough just to convert those to UNIX-style.