### PR TITLE
Fix for inexistent `environb` on some platforms

### DIFF
--- a/docs/prysk_news.rst
+++ b/docs/prysk_news.rst
@@ -1,5 +1,6 @@
 Unreleased
 -----------------------------------------------------
+* Prevent prysk from crashing on platforms which do not support :code:`os.envronb`
 
 Version 0.15.0 (April. 26, 2023)
 -----------------------------------------------------

--- a/prysk/test.py
+++ b/prysk/test.py
@@ -220,7 +220,7 @@ def test(
                 if os.supports_bytes_environ:
                     tmpdir = os.environb[b"TMPDIR"]
                 else:
-                    tmpdir = str.encode(os.environ["TMPDIR"])
+                    tmpdir = os.environ["TMPDIR"].encode()
             except KeyError:
                 pass
             else:

--- a/prysk/test.py
+++ b/prysk/test.py
@@ -226,10 +226,7 @@ def test(
                 out = _escape(out)
 
             try:
-                if os.supports_bytes_environ:
-                    tmpdir = os.environb[b"TMPDIR"]
-                else:
-                    tmpdir = os.environ["TMPDIR"].encode()
+                tmpdir = os.environ["TMPDIR"].encode()
             except KeyError:
                 pass
             else:

--- a/prysk/test.py
+++ b/prysk/test.py
@@ -217,7 +217,10 @@ def test(
                 out = _escape(out)
 
             try:
-                tmpdir = os.environb[b"TMPDIR"]
+                if os.supports_bytes_environ:
+                    tmpdir = os.environb[b"TMPDIR"]
+                else:
+                    tmpdir = str.encode(os.environ["TMPDIR"])
             except KeyError:
                 pass
             else:


### PR DESCRIPTION
Background:
We run prysk on a bash shell in Windows, using a Windows platform Python. Windows Python `os` module does not have environb, so it stopped working after https://github.com/Nicoretti/prysk/pull/177
